### PR TITLE
Use the total kwarg as the tqdm length if provided. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ p_tqdm.egg-info
 __pycache__
 *.pyc
 .idea
+venv
+.venv

--- a/p_tqdm/p_tqdm.py
+++ b/p_tqdm/p_tqdm.py
@@ -38,8 +38,9 @@ def _parallel(ordered: bool, function: Callable, *iterables: Iterable, **kwargs:
     elif type(num_cpus) == float:
         num_cpus = int(round(num_cpus * cpu_count()))
 
-    # Determine length of tqdm (equal to length of shortest iterable)
-    length = min(len(iterable) for iterable in iterables if isinstance(iterable, Sized))
+    # Determine length of tqdm (equal to length of shortest iterable or total kwarg)
+    total = kwargs.pop('total', None)
+    length = total or min(len(iterable) for iterable in iterables if isinstance(iterable, Sized))
 
     # Create parallel generator
     map_type = 'imap' if ordered else 'uimap'


### PR DESCRIPTION
Use the `total` kwarg as the `tqdm` length if provided. This is important when mapping generators.